### PR TITLE
Add if_exists option to persistence-related methods

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -119,8 +119,9 @@ module Cequel
       #
       # @return [void]
       #
-      # @note `UPDATE` statements will succeed even if targeting a row that
-      #   does not exist. In this case a new row will be created.
+      # @note By default `UPDATE` statements will succeed even if targeting
+      #   a row that does not exist. In this case a new row will be created.
+      #   To prevent this behavior use `if_exists` option set to `true`.
       # @note This statement will fail unless one or more rows are fully
       #   specified by primary key using `where`
       # @note If a enclosed in a Keyspace#batch block, this method will be

--- a/lib/cequel/metal/updater.rb
+++ b/lib/cequel/metal/updater.rb
@@ -163,6 +163,14 @@ module Cequel
         end
         [all_statements, all_bind_vars]
       end
+
+      def finalize_statement(statement, options)
+        statement.append(generate_if_exists_clause(options))
+      end
+
+      def generate_if_exists_clause(options)
+        options[:if_exists] ? ' IF EXISTS' : ''
+      end
     end
   end
 end

--- a/lib/cequel/metal/updater.rb
+++ b/lib/cequel/metal/updater.rb
@@ -163,14 +163,6 @@ module Cequel
         end
         [all_statements, all_bind_vars]
       end
-
-      def finalize_statement(statement, options)
-        statement.append(generate_if_exists_clause(options))
-      end
-
-      def generate_if_exists_clause(options)
-        options[:if_exists] ? ' IF EXISTS' : ''
-      end
     end
   end
 end

--- a/lib/cequel/metal/writer.rb
+++ b/lib/cequel/metal/writer.rb
@@ -94,12 +94,8 @@ module Cequel
             'EXISTS'
           when :not_exists
             'NOT EXISTS'
-          when Hash
-            if_options.map { |key, value| "#{key} = #{value}" }.join(' AND ')
-          when String
-            if_options
           else
-            # TODO raise exception
+            raise ArgumentError, "Unsupported `IF` option provided"
           end
 
         ' IF ' + serialized_if_options

--- a/lib/cequel/metal/writer.rb
+++ b/lib/cequel/metal/writer.rb
@@ -5,7 +5,9 @@ module Cequel
     # Internal representation of a data manipulation statement
     #
     # @abstract Subclasses must implement #write_to_statement, which writes
-    #   internal state to a Statement instance
+    #   internal state to a Statement instance. Subclasses may implement
+    #   #finalize_statement which adds final clauses to a Statement
+    #   instance state.
     #
     # @since 1.0.0
     # @api private
@@ -34,15 +36,18 @@ module Cequel
       #   data
       # @option options [Time,Integer] :timestamp the timestamp associated with
       #   the column values
+      # @option options [Boolean] :if_exists defines if `IF EXISTS` modifier
+      #   should be added to the statement (makes sense to UPDATE only)
       # @return [void]
       #
       def execute(options = {})
-        options.assert_valid_keys(:timestamp, :ttl, :consistency)
+        options.assert_valid_keys(:timestamp, :ttl, :consistency, :if_exists)
         return if empty?
         statement = Statement.new
         consistency = options.fetch(:consistency, data_set.query_consistency)
         write_to_statement(statement, options)
         statement.append(*data_set.row_specifications_cql)
+        finalize_statement(statement, options)
         data_set.write_with_options(statement,
                                     consistency: consistency)
       end
@@ -75,6 +80,9 @@ module Cequel
             "#{key.to_s.upcase} #{serialized_value}"
           end.join(' AND ')
         end
+      end
+
+      def finalize_statement(_statement, _options)
       end
     end
   end

--- a/lib/cequel/metal/writer.rb
+++ b/lib/cequel/metal/writer.rb
@@ -6,7 +6,7 @@ module Cequel
     #
     # @abstract Subclasses must implement #write_to_statement, which writes
     #   internal state to a Statement instance. Subclasses may implement
-    #   #finalize_statement which adds final clauses to a Statement
+    #   #if_statement which adds final clauses to a Statement
     #   instance state.
     #
     # @since 1.0.0
@@ -36,18 +36,18 @@ module Cequel
       #   data
       # @option options [Time,Integer] :timestamp the timestamp associated with
       #   the column values
-      # @option options [Boolean] :if_exists defines if `IF EXISTS` modifier
-      #   should be added to the statement (makes sense to UPDATE only)
+      # @option options [Boolean] :if defines `IF <condition>` clause to be
+      #   to the operations statement, if supported.
       # @return [void]
       #
       def execute(options = {})
-        options.assert_valid_keys(:timestamp, :ttl, :consistency, :if_exists)
+        options.assert_valid_keys(:timestamp, :ttl, :consistency, :if)
         return if empty?
         statement = Statement.new
         consistency = options.fetch(:consistency, data_set.query_consistency)
         write_to_statement(statement, options)
         statement.append(*data_set.row_specifications_cql)
-        finalize_statement(statement, options)
+        if_statement(statement, options)
         data_set.write_with_options(statement,
                                     consistency: consistency)
       end
@@ -82,7 +82,27 @@ module Cequel
         end
       end
 
-      def finalize_statement(_statement, _options)
+      def if_statement(statement, options)
+        return unless options.key?(:if)
+        statement.append(generate_if_options(options[:if]))
+      end
+
+      def generate_if_options(if_options)
+        serialized_if_options =
+          case if_options
+          when :exists
+            'EXISTS'
+          when :not_exists
+            'NOT EXISTS'
+          when Hash
+            if_options.map { |key, value| "#{key} = #{value}" }.join(' AND ')
+          when String
+            if_options
+          else
+            # TODO raise exception
+          end
+
+        ' IF ' + serialized_if_options
       end
     end
   end

--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -179,13 +179,15 @@ module Cequel
       #   seconds
       # @option options [Time] :timestamp the writetime to use for the column
       #   updates
+      # @option options [Boolean] :if_exists defines if `IF EXISTS` modifier
+      #   should be added to the update statement.
       # @return [Boolean] true if record saved successfully, false if invalid
       #
       # @see Validations#save!
       #
       def save(options = {})
-        options.assert_valid_keys(:consistency, :ttl, :timestamp)
-        if new_record? then create(options)
+        options.assert_valid_keys(:consistency, :ttl, :timestamp, :if_exists)
+        if new_record? then create(options.except(:if_exists))
         else update(options)
         end
         @new_record = false
@@ -196,15 +198,18 @@ module Cequel
       # Set attributes and save the record
       #
       # @param attributes [Hash] hash of attributes to update
+      # @option options [Boolean] :if_exists defines if `IF EXISTS` modifier
+      #   should be added to the update statement.
       # @return [Boolean] true if saved successfully
       #
       # @see #save
       # @see Properties#attributes=
       # @see Validations#update_attributes!
       #
-      def update_attributes(attributes)
+      def update_attributes(attributes, options = {})
+        options.assert_valid_keys(:if_exists)
         self.attributes = attributes
-        save
+        save(options)
       end
 
       #

--- a/lib/cequel/record/persistence.rb
+++ b/lib/cequel/record/persistence.rb
@@ -179,15 +179,15 @@ module Cequel
       #   seconds
       # @option options [Time] :timestamp the writetime to use for the column
       #   updates
-      # @option options [Boolean] :if_exists defines if `IF EXISTS` modifier
-      #   should be added to the update statement.
+      # @option options [Boolean] :if defines `IF` modifier to be added to an
+      #   insert or update operation.
       # @return [Boolean] true if record saved successfully, false if invalid
       #
       # @see Validations#save!
       #
       def save(options = {})
-        options.assert_valid_keys(:consistency, :ttl, :timestamp, :if_exists)
-        if new_record? then create(options.except(:if_exists))
+        options.assert_valid_keys(:consistency, :ttl, :timestamp, :if)
+        if new_record? then create(options)
         else update(options)
         end
         @new_record = false
@@ -198,7 +198,7 @@ module Cequel
       # Set attributes and save the record
       #
       # @param attributes [Hash] hash of attributes to update
-      # @option options [Boolean] :if_exists defines if `IF EXISTS` modifier
+      # @option options [Boolean] :if defines if `IF` modifier
       #   should be added to the update statement.
       # @return [Boolean] true if saved successfully
       #
@@ -207,7 +207,7 @@ module Cequel
       # @see Validations#update_attributes!
       #
       def update_attributes(attributes, options = {})
-        options.assert_valid_keys(:if_exists)
+        options.assert_valid_keys(:if)
         self.attributes = attributes
         save(options)
       end
@@ -223,7 +223,7 @@ module Cequel
       # @return [Record] self
       #
       def destroy(options = {})
-        options.assert_valid_keys(:consistency, :timestamp)
+        options.assert_valid_keys(:consistency, :timestamp, :if)
         assert_keys_present!
         metal_scope.delete(options)
         transient!

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../spec_helper', __FILE__)
 
 describe Cequel::Metal::DataSet do
   posts_tn = "posts_#{SecureRandom.hex(4)}"
-  post_act_tn = "post_activity_#{SecureRandom.hex(4)}" 
+  post_act_tn = "post_activity_#{SecureRandom.hex(4)}"
 
   before :all do
     cequel.schema.create_table(posts_tn) do
@@ -110,6 +110,18 @@ describe Cequel::Metal::DataSet do
         update(:title => 'Fun times', :body => 'Fun')
       expect(cequel[posts_tn].where(row_keys).
         first[:title]).to eq('Fun times')
+    end
+
+    it "it should update only existing records" do
+      cequel[posts_tn].where(row_keys).delete
+      cequel[posts_tn].where(row_keys).update(
+        {
+          :title => 'Fun times',
+          :body => 'Fun'
+        },
+        :if_exists => true
+      )
+      expect(cequel[posts_tn].where(row_keys).first).to be_nil
     end
 
     it 'should send update statement with options' do

--- a/spec/examples/metal/data_set_spec.rb
+++ b/spec/examples/metal/data_set_spec.rb
@@ -112,18 +112,6 @@ describe Cequel::Metal::DataSet do
         first[:title]).to eq('Fun times')
     end
 
-    it "it should update only existing records" do
-      cequel[posts_tn].where(row_keys).delete
-      cequel[posts_tn].where(row_keys).update(
-        {
-          :title => 'Fun times',
-          :body => 'Fun'
-        },
-        :if_exists => true
-      )
-      expect(cequel[posts_tn].where(row_keys).first).to be_nil
-    end
-
     it 'should send update statement with options' do
       cequel.schema.truncate_table(posts_tn)
       time = Time.now - 10.minutes
@@ -192,6 +180,18 @@ describe Cequel::Metal::DataSet do
         set(title: 'Even Bigger Data')
       end
       expect(cequel[posts_tn].where(row_keys).first[:title]).to eq('Even Bigger Data')
+    end
+
+    it "it should update only existing records with if: :exists option" do
+      cequel[posts_tn].where(row_keys).delete
+      cequel[posts_tn].where(row_keys).update(
+        {
+          :title => 'Fun times',
+          :body => 'Fun'
+        },
+        :if => :exists
+      )
+      expect(cequel[posts_tn].where(row_keys).first).to be_nil
     end
   end
 

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -157,6 +157,14 @@ describe Cequel::Record::Persistence do
           blog.save
           expect(subject[:name]).to eq('Pizza')
         end
+
+        it "should not upsert non-existing rows with `if_exists` set to true" do
+          memoized_clone = Blog.find(blog.subdomain)
+          blog.destroy
+          memoized_clone.name = 'Yet Another Blog'
+          memoized_clone.save(:if_exists => true)
+          expect(Blog.where(subdomain: memoized_clone.subdomain).first).to be_nil
+        end
       end
     end
 
@@ -227,6 +235,13 @@ describe Cequel::Record::Persistence do
       it 'should not allow updating key values' do
         expect { blog.update_attributes(:subdomain => 'soup') }
           .to raise_error(ArgumentError)
+      end
+
+      it "should not upsert non-existing rows with `if_exists` set to true" do
+        memoized_clone = Blog.find(blog.subdomain)
+        blog.destroy
+        memoized_clone.update_attributes({:name => 'Yet Another Blog'}, :if_exists => true)
+        expect(Blog.where(subdomain: memoized_clone.subdomain).first).to be_nil
       end
     end
 

--- a/spec/examples/record/persistence_spec.rb
+++ b/spec/examples/record/persistence_spec.rb
@@ -279,11 +279,6 @@ describe Cequel::Record::Persistence do
         blog.destroy(timestamp: 1.hour.ago)
         expect(cequel[Blog.table_name].where(subdomain: 'big-data').first).to be
       end
-
-      it 'should fail with IF EXISTS option provided for non-existing record' do
-        binding.pry
-        expect { blog.destroy(if: :exists) }.not_to raise_error
-      end
     end
   end
 


### PR DESCRIPTION
By default, `UPDATE` operation in CQL 3.x actually behaves like upsert - update inserts the new row if it doesn't exist. Sometimes this default behavior causes pain _and_ CQL 3.x supports `IF EXISTS` update modifier that solves the problem (https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlUpdate.html#cqlUpdate__if-exists)

This PR adds `if_exists` option that can be provided for update-related persistence methods.